### PR TITLE
Output paths default to current working directory

### DIFF
--- a/Examples/Scotty_main_circularFluxSurfaces.py
+++ b/Examples/Scotty_main_circularFluxSurfaces.py
@@ -35,7 +35,6 @@ kwargs_dict = {
     "B_p_a": 0.1,
     "R_axis": 1.5,
     "minor_radius_a": 0.5,
-    "output_path": "D:\\Dropbox\\VHChen\\GitHub\\Scotty\\Output\\",
 }
 
 beam_me_up(**args_dict, **kwargs_dict)


### PR DESCRIPTION
Uses the [`pathlib`](https://docs.python.org/3/library/pathlib.html) module to handle paths. This handles the Windows/Linux directory separators for us using the `/` operator.

Previously the default output directory was `os.path.dirname(os.path.abspath(__file__))` which is now the `scotty` package itself. Instead we use `pathlib.Path(".")` which will be the current working directory, wherever the Scotty script is called from.