### PR TITLE
Check that launch position is not inside plasma

### DIFF
--- a/scotty/beam_me_up.py
+++ b/scotty/beam_me_up.py
@@ -311,9 +311,6 @@ def beam_me_up(
     # Input data #
     # ------------------------------
 
-    # Checking input data
-    check_input(mode_flag)
-
     # Tidying up the input data
     launch_angular_frequency = freq_GHz_to_angular_frequency(launch_freq_GHz)
     wavenumber_K0 = angular_frequency_to_wavenumber(launch_angular_frequency)
@@ -373,6 +370,9 @@ def beam_me_up(
         delta_K_zeta,
         delta_K_Z,
     )
+
+    # Checking input data
+    check_input(mode_flag, poloidal_flux_enter, launch_position, field)
 
     # -------------------
     # Launch parameters

--- a/scotty/check_input.py
+++ b/scotty/check_input.py
@@ -6,6 +6,9 @@
 
 from __future__ import annotations
 
+from .typing import FloatArray
+from .geometry import MagneticField
+
 
 def check_mode_flag(mode_flag: int) -> None:
     """Mode flag should be either -1 (X-mode) or 1 (O-mode)"""
@@ -16,5 +19,23 @@ def check_mode_flag(mode_flag: int) -> None:
         )
 
 
-def check_input(mode_flag: int) -> None:
+def check_launch_position(
+    poloidal_flux_enter: float, launch_position: FloatArray, field: MagneticField
+) -> None:
+    R, _, Z = launch_position
+    launch_psi = field.poloidal_flux(R, Z)
+
+    if launch_psi < poloidal_flux_enter:
+        raise ValueError(
+            f"Launch position (R={R:.4f}, Z={Z:.4f}, psi={launch_psi:.4f}) is inside plasma (psi={poloidal_flux_enter})"
+        )
+
+
+def check_input(
+    mode_flag: int,
+    poloidal_flux_enter: float,
+    launch_position: FloatArray,
+    field: MagneticField,
+) -> None:
     check_mode_flag(mode_flag)
+    check_launch_position(poloidal_flux_enter, launch_position, field)


### PR DESCRIPTION
This hard-errors if the the $\psi$ of the launch position is inside `poloidal_flux_enter`. If this is actually something we want to support, then could just make it a warning? In that case, in `launch.find_entry_point` we could just bail early and set the entry point at the launch position.