### PR TITLE
Automate publishing package on GitHub release

### DIFF
--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -1,0 +1,25 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build --sdist --wheel
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,16 @@ Beam tracing for tokamak DBS diagnostics
 Install
 -------
 
-To install `scotty` straight from Github:
+Scotty can be installed using `pip`:
+
+```
+pip install scotty-beam-tracing
+```
+
+Note that the package to install is called `scotty-beam-tracing`, but
+the python module is just `scotty`.
+
+To install the development version of `scotty` straight from Github:
 
 ```
 pip install git+https://github.com/beam-tracing/Scotty
@@ -32,6 +41,3 @@ Description of the Scotty [[1]](#1), derivation of beam tracing given in Appendi
 Hall-Chen, V. H., Parra, F. I., & Hillesheim, J. C. (2022). 
 [Beam model of Doppler backscattering](https://iopscience.iop.org/article/10.1088/1361-6587/ac57a1). 
 *Plasma Physics and Controlled Fusion*, **64**(9), 095002.
-
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "Scotty"
+name = "scotty-beam-tracing"
 description = "Beam tracing for tokamak DBS diagnostics"
 requires-python = ">3.7"
 readme = "README.md"


### PR DESCRIPTION
The version before most of my changes is v2.3.0 and is now available on pypi as `scotty-beam-tracing`.