### PR TITLE
Support older versions of numpy, scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,10 @@ readme = "README.md"
 authors = [{name = "Valerian Hall-Chen"}]
 urls = {project = "https://github.com/valerian-chen/Scotty"}
 dependencies = [
-    "numpy",
-    "scipy",
-    "matplotlib",
-    "netCDF4",
+    "numpy~=1.20",
+    "scipy~=1.7",
+    "matplotlib~=3.3",
+    "netCDF4~=1.5",
     "freeqdsk==0.1.0",
 ]
 dynamic = ["version"]

--- a/scotty/beam_me_up.py
+++ b/scotty/beam_me_up.py
@@ -2120,6 +2120,8 @@ def create_magnetic_geometry(
                 psi_norm_2D=loadfile["poloidalFlux_grid"],
                 psi_unnorm_axis=loadfile["poloidalFlux_unnormalised_axis"],
                 psi_unnorm_boundary=loadfile["poloidalFlux_unnormalised_boundary"],
+                delta_R=delta_R,
+                delta_Z=delta_Z,
                 interp_order=interp_order,
                 interp_smoothing=interp_smoothing,
             )
@@ -2136,6 +2138,8 @@ def create_magnetic_geometry(
         return EFITField.from_EFITpp(
             magnetic_data_path / "efitOut.nc",
             equil_time,
+            delta_R,
+            delta_Z,
             interp_order,
             interp_smoothing,
         )
@@ -2146,7 +2150,7 @@ def create_magnetic_geometry(
         # data saved differently for MAST-U shots
         filename = magnetic_data_path / f"{shot}_equilibrium_data.npz"
         return EFITField.from_MAST_saved(
-            filename, equil_time, interp_order, interp_smoothing
+            filename, equil_time, delta_R, delta_Z, interp_order, interp_smoothing
         )
 
     if find_B_method == "UDA_saved" and shot is not None and shot > 30471:  # MAST-U
@@ -2155,7 +2159,7 @@ def create_magnetic_geometry(
         # data saved differently for MAST-U shots
         filename = magnetic_data_path / f"{shot}_equilibrium_data.npz"
         return EFITField.from_MAST_U_saved(
-            filename, equil_time, interp_order, interp_smoothing
+            filename, equil_time, delta_R, delta_Z, interp_order, interp_smoothing
         )
 
     raise ValueError(f"Invalid find_B_method '{find_B_method}'")

--- a/scotty/fun_general.py
+++ b/scotty/fun_general.py
@@ -10,13 +10,12 @@ from scipy import constants as constants
 from scipy import interpolate as interpolate
 from scipy import integrate as integrate
 from typing import TextIO, List, Any, Tuple
-from numpy.typing import NDArray
-from scotty.typing import ArrayLike
+from scotty.typing import ArrayLike, FloatArray
 
 from .typing import ArrayLike
 
 
-def read_floats_into_list_until(terminator: str, lines: TextIO) -> NDArray[np.float64]:
+def read_floats_into_list_until(terminator: str, lines: TextIO) -> FloatArray:
     """Reads the lines of a file until the string (terminator) is read.
 
     Currently used to read topfile.
@@ -37,7 +36,7 @@ def read_floats_into_list_until(terminator: str, lines: TextIO) -> NDArray[np.fl
     return np.asarray(lst)
 
 
-def find_nearest(array: NDArray, value: Any) -> int:
+def find_nearest(array: ArrayLike, value: Any) -> int:
     """Returns the index of the first element in ``array`` closest in
     absolute value to ``value``
 
@@ -47,7 +46,7 @@ def find_nearest(array: NDArray, value: Any) -> int:
     return int(idx)
 
 
-def contract_special(arg_a: NDArray, arg_b: NDArray) -> NDArray:
+def contract_special(arg_a: FloatArray, arg_b: FloatArray) -> FloatArray:
     """Dot product of arrays of vectors or matrices.
 
     Covers the case that matmul and dot don't do very elegantly, and

--- a/scotty/typing.py
+++ b/scotty/typing.py
@@ -4,8 +4,11 @@
 from os import PathLike as os_PathLike
 from typing import Union
 import numpy as np
-from numpy.typing import NDArray
+try:
+    from numpy.typing import NDArray
+    FloatArray = NDArray[np.float64]
+except ImportError:
+    FloatArray = np.ndarray     # type: ignore
 
-FloatArray = NDArray[np.float64]
 ArrayLike = Union[float, FloatArray]
 PathLike = Union[os_PathLike, str]

--- a/scotty/typing.py
+++ b/scotty/typing.py
@@ -4,11 +4,13 @@
 from os import PathLike as os_PathLike
 from typing import Union
 import numpy as np
+
 try:
     from numpy.typing import NDArray
+
     FloatArray = NDArray[np.float64]
 except ImportError:
-    FloatArray = np.ndarray     # type: ignore
+    FloatArray = np.ndarray  # type: ignore
 
 ArrayLike = Union[float, FloatArray]
 PathLike = Union[os_PathLike, str]


### PR DESCRIPTION
Add shims and fall-back functionality to support `numpy==1.20.3` and `scipy==1.7.3`.

- Use `shgo` global optimiser for SciPy < 1.9. This is a little slower than `direct` but does still seem to work
- Fall back to `np.ndarray` for some type hints for numpy < 1.21. This is less specific, but makes no difference at runtime
- For interpolated magnetic fields, fall back to explicit finite differences for poloidal flux derivatives for scipy < 1.9, using the `MagneticField` base class implementations. This means we have to pass `delta_R/Z` back to the EFIT fields, but if the user doesn't set them, they'll still get sensible values.

@quinntpratt I've checked this all works in a python 3.9 virtual environment, but maybe you want to check this works on `iris`?