### PR TITLE
Attempt to more robustly find entry point

### DIFF
--- a/scotty/launch.py
+++ b/scotty/launch.py
@@ -20,17 +20,8 @@ from typing import Union
 import warnings
 
 import numpy as np
-
-try:
-    from scipy.optimize import direct as minimise, root_scalar
-except ImportError:
-    # For SciPy < 1.9, `direct` isn't available, so we use a different
-    # global optimiser, but make a shim to ignore `direct`-specific
-    # arguments
-    from scipy.optimize import shgo, root_scalar
-
-    def minimise(func, bounds, **kwargs):
-        return shgo(func, bounds, sampling_method="sobol")
+from scipy.optimize import minimize_scalar, root_scalar
+from scipy.interpolate import CubicSpline
 
 
 def launch_beam(
@@ -289,7 +280,7 @@ def launch_beam(
         Psi_3D_lab_initial = Psi_3D_lab_entry
 
     return (
-        K_initial,
+        np.array(K_initial),
         initial_position,
         launch_K,
         Psi_3D_lab_initial,
@@ -369,22 +360,17 @@ def find_entry_point(
         R, _, Z = cartesian_to_cylindrical(*beam_line(tau))
         return field.poloidal_flux(R, Z) - poloidal_flux_enter
 
-    # Find the plasma boundary using a bracket search. We need the
-    # minimum so that the flux has different sign to our initial
-    # position for the bracket points. There could be one or two
-    # minima (corresponding to the two halves of the torus), we only
-    # care about the closest, so use the first result as a bound for
-    # the second. If there isn't a second, this will just find the
-    # first again
-    first_min = minimise(
-        poloidal_flux_boundary_along_line, bounds=((0, 1),), len_tol=1e-3
+    tau = np.linspace(0, 1, 100)
+    spline = CubicSpline(
+        tau, [poloidal_flux_boundary_along_line(t) for t in tau], extrapolate=False
     )
-    minimum = minimise(
-        poloidal_flux_boundary_along_line, bounds=((0, first_min.x[0]),), len_tol=1e-3
-    )
-    # If the closest minimum is positive, then the beam never actually
-    # enters the plasma, and we should abort
-    if minimum.fun > 0:
+    spline_roots = spline.roots()
+
+    # If there are no roots, then the beam never actually enters the
+    # plasma, and we should abort
+    if len(spline_roots) == 0:
+        # Get an idea of the location of the closest point
+        minimum = minimize_scalar(poloidal_flux_boundary_along_line)
         R_miss, zeta_miss, Z_miss = cartesian_to_cylindrical(*beam_line(minimum.x))
         miss_coords = f"(R={R_miss}, zeta={zeta_miss}, Z={Z_miss})"
         raise RuntimeError(
@@ -392,10 +378,9 @@ def find_entry_point(
             f"distance in poloidal flux to boundary={minimum.fun}"
         )
 
-    # `minimum.x` is some point along the beam that's definitely
-    # inside the plasma. So any root between the start of the beam and
-    # this point is the closest entry point
-    boundary = root_scalar(poloidal_flux_boundary_along_line, bracket=(0, minimum.x))
+    # The spline roots is a pretty good guess for the boundary
+    # location, which we now try to refine
+    boundary = root_scalar(poloidal_flux_boundary_along_line, x0=spline_roots[0])
     if not boundary.converged:
         raise RuntimeError(
             f"Could not find plasma boundary, root finding failed with '{boundary.flag}'"
@@ -408,4 +393,4 @@ def find_entry_point(
     if field.poloidal_flux(R_boundary, Z_boundary) > poloidal_flux_enter:
         boundary_tau += boundary_adjust
 
-    return np.array(cartesian_to_cylindrical(*beam_line(boundary.root)))
+    return np.array(cartesian_to_cylindrical(*beam_line(boundary_tau)))

--- a/scotty/launch.py
+++ b/scotty/launch.py
@@ -380,7 +380,9 @@ def find_entry_point(
 
     # The spline roots is a pretty good guess for the boundary
     # location, which we now try to refine
-    boundary = root_scalar(poloidal_flux_boundary_along_line, x0=spline_roots[0])
+    boundary = root_scalar(
+        poloidal_flux_boundary_along_line, x0=spline_roots[0], x1=spline_roots[0] + 1e-3
+    )
     if not boundary.converged:
         raise RuntimeError(
             f"Could not find plasma boundary, root finding failed with '{boundary.flag}'"

--- a/tests/test_simple_golden.py
+++ b/tests/test_simple_golden.py
@@ -13,6 +13,7 @@ from scotty.fun_general import (
 from scotty.profile_fit import QuadraticFit, TanhFit, PolynomialFit, ProfileFit
 from scotty.hamiltonian import Hamiltonian
 from scotty.launch import find_entry_point, launch_beam
+from scotty.typing import FloatArray
 
 import json
 import numpy as np
@@ -1007,6 +1008,35 @@ def UDA_saved_MAST_U(path: pathlib.Path):
     return kwargs_dict
 
 
+def assert_is_symmetric(array: FloatArray) -> None:
+    assert_allclose(array, array.T)
+
+
+def check_Psi(
+    result: FloatArray,
+    expected_start: FloatArray,
+    cutoff_index: int,
+    expected_cutoff: FloatArray,
+    expected_final: FloatArray,
+):
+    assert_is_symmetric(result[0, ...])
+
+    # Mixed zeta elements: comparitively large atol because these are
+    # expected to be zero
+    assert np.isclose(result[0, 0, 1], expected_start[0, 1], rtol=1e-2, atol=0.4)
+    assert np.isclose(result[0, 1, 2], expected_start[1, 2], rtol=1e-2, atol=0.4)
+
+    # Diagonal elements
+    assert_allclose(
+        result[0, ...].diagonal(), expected_start.diagonal(), rtol=1e-2, atol=0.1
+    )
+    # RZ element
+    assert np.isclose(result[0, 0, 2], expected_start[0, 2], rtol=1e-2, atol=0.1)
+
+    assert_allclose(result[cutoff_index, ...], expected_cutoff, rtol=1e-2, atol=0.1)
+    assert_allclose(result[-1, ...], expected_final, rtol=1.8e-2, atol=0.1)
+
+
 @pytest.mark.parametrize(
     "generator",
     [
@@ -1044,17 +1074,12 @@ def test_integrated_O_mode(tmp_path, generator):
     K_magnitude = np.hypot(output["K_R_array"], output["K_Z_array"])
     assert K_magnitude.argmin() == CUTOFF_INDEX_1
 
-    assert_allclose(
-        output["Psi_3D_output"][0, ...], PSI_START_EXPECTED_1, rtol=1e-2, atol=0.1
-    )
-    assert_allclose(
-        output["Psi_3D_output"][CUTOFF_INDEX_1, ...],
+    check_Psi(
+        output["Psi_3D_output"],
+        PSI_START_EXPECTED_1,
+        CUTOFF_INDEX_1,
         PSI_CUTOFF_EXPECTED_1,
-        rtol=1e-2,
-        atol=0.1,
-    )
-    assert_allclose(
-        output["Psi_3D_output"][-1, ...], PSI_FINAL_EXPECTED_1, rtol=1.8e-2, atol=0.1
+        PSI_FINAL_EXPECTED_1,
     )
 
 
@@ -1097,17 +1122,12 @@ def test_integrated_X_mode(tmp_path, generatorneg):
     K_magnitude = np.hypot(output["K_R_array"], output["K_Z_array"])
     assert K_magnitude.argmin() == CUTOFF_INDEX_NEG1
 
-    assert_allclose(
-        output["Psi_3D_output"][0, ...], PSI_START_EXPECTED_NEG1, rtol=1e-2, atol=0.1
-    )
-    assert_allclose(
-        output["Psi_3D_output"][CUTOFF_INDEX_NEG1, ...],
+    check_Psi(
+        output["Psi_3D_output"],
+        PSI_START_EXPECTED_NEG1,
+        CUTOFF_INDEX_NEG1,
         PSI_CUTOFF_EXPECTED_NEG1,
-        rtol=1e-2,
-        atol=0.1,
-    )
-    assert_allclose(
-        output["Psi_3D_output"][-1, ...], PSI_FINAL_EXPECTED_NEG1, rtol=1.8e-2, atol=0.1
+        PSI_FINAL_EXPECTED_NEG1,
     )
 
 
@@ -1150,20 +1170,12 @@ def test_relativistic_O_mode(tmp_path, generator_rel):
     K_magnitude = np.hypot(output["K_R_array"], output["K_Z_array"])
     assert K_magnitude.argmin() == CUTOFF_INDEX_REL_1
 
-    assert_allclose(
-        output["Psi_3D_output"][0, ...], PSI_START_EXPECTED_REL_1, rtol=1e-2, atol=0.1
-    )
-    assert_allclose(
-        output["Psi_3D_output"][CUTOFF_INDEX_REL_1, ...],
+    check_Psi(
+        output["Psi_3D_output"],
+        PSI_START_EXPECTED_REL_1,
+        CUTOFF_INDEX_REL_1,
         PSI_CUTOFF_EXPECTED_REL_1,
-        rtol=1e-2,
-        atol=0.1,
-    )
-    assert_allclose(
-        output["Psi_3D_output"][-1, ...],
         PSI_FINAL_EXPECTED_REL_1,
-        rtol=1.8e-2,
-        atol=0.1,
     )
 
 
@@ -1207,23 +1219,12 @@ def test_relativistic_X_mode(tmp_path, generator_relneg):
     K_magnitude = np.hypot(output["K_R_array"], output["K_Z_array"])
     assert K_magnitude.argmin() == CUTOFF_INDEX_REL_NEG1
 
-    assert_allclose(
-        output["Psi_3D_output"][0, ...],
+    check_Psi(
+        output["Psi_3D_output"],
         PSI_START_EXPECTED_REL_NEG1,
-        rtol=1e-2,
-        atol=0.1,
-    )
-    assert_allclose(
-        output["Psi_3D_output"][CUTOFF_INDEX_REL_NEG1, ...],
+        CUTOFF_INDEX_REL_NEG1,
         PSI_CUTOFF_EXPECTED_REL_NEG1,
-        rtol=1e-2,
-        atol=0.1,
-    )
-    assert_allclose(
-        output["Psi_3D_output"][-1, ...],
         PSI_FINAL_EXPECTED_REL_NEG1,
-        rtol=1.8e-2,
-        atol=0.1,
     )
 
 
@@ -1268,17 +1269,12 @@ def test_null_relativistic_O_mode(tmp_path, generator_nullrel):
     K_magnitude = np.hypot(output["K_R_array"], output["K_Z_array"])
     assert K_magnitude.argmin() == CUTOFF_INDEX_1
 
-    assert_allclose(
-        output["Psi_3D_output"][0, ...], PSI_START_EXPECTED_1, rtol=1e-2, atol=0.1
-    )
-    assert_allclose(
-        output["Psi_3D_output"][CUTOFF_INDEX_1, ...],
+    check_Psi(
+        output["Psi_3D_output"],
+        PSI_START_EXPECTED_1,
+        CUTOFF_INDEX_1,
         PSI_CUTOFF_EXPECTED_1,
-        rtol=1e-2,
-        atol=0.1,
-    )
-    assert_allclose(
-        output["Psi_3D_output"][-1, ...], PSI_FINAL_EXPECTED_1, rtol=1.8e-2, atol=0.1
+        PSI_FINAL_EXPECTED_1,
     )
 
 
@@ -1324,17 +1320,12 @@ def test_null_relativistic_X_mode(tmp_path, generator_nullrelneg):
     K_magnitude = np.hypot(output["K_R_array"], output["K_Z_array"])
     assert K_magnitude.argmin() == CUTOFF_INDEX_NEG1
 
-    assert_allclose(
-        output["Psi_3D_output"][0, ...], PSI_START_EXPECTED_NEG1, rtol=1e-2, atol=0.1
-    )
-    assert_allclose(
-        output["Psi_3D_output"][CUTOFF_INDEX_NEG1, ...],
+    check_Psi(
+        output["Psi_3D_output"],
+        PSI_START_EXPECTED_NEG1,
+        CUTOFF_INDEX_NEG1,
         PSI_CUTOFF_EXPECTED_NEG1,
-        rtol=1e-2,
-        atol=0.1,
-    )
-    assert_allclose(
-        output["Psi_3D_output"][-1, ...], PSI_FINAL_EXPECTED_NEG1, rtol=1.8e-2, atol=0.1
+        PSI_FINAL_EXPECTED_NEG1,
     )
 
 
@@ -1544,7 +1535,7 @@ def test_launch_golden_answer(tmp_path, generator):
         Psi_3D_lab_entry_cartersian, expected_Psi_3D_lab_entry_cartersian, tol, tol
     )
     # Larger atol due to some small values
-    assert_allclose(Psi_3D_lab_initial, expected_Psi_3D_lab_initial, tol, atol=0.1)
+    assert_allclose(Psi_3D_lab_initial, expected_Psi_3D_lab_initial, tol, atol=0.4)
 
 
 def launch_parameters(start_point, end_point_poloidal_coords):
@@ -1570,6 +1561,7 @@ def launch_parameters(start_point, end_point_poloidal_coords):
     "generator",
     [
         pytest.param(simple, id="simple"),
+        pytest.param(ne_dat_file, id="density-fit-file"),
         pytest.param(torbeam_file, id="torbeam-file"),
         pytest.param(npz_file, id="test-file"),
         pytest.param(UDA_saved, id="UDA-saved-file"),
@@ -1628,6 +1620,20 @@ def test_find_entry_point(
     )
 
     assert_allclose(entry_position, expected_entry, 1e-6, 1e-6)
+
+
+def test_find_entry_point_bug(tmp_path):
+    args = simple(tmp_path)
+    field = create_magnetic_geometry(**args)
+    R, zeta, Z = find_entry_point(
+        launch_position=[2.3, 0, -0.1],
+        poloidal_launch_angle=np.deg2rad(-1),
+        toroidal_launch_angle=0.0,
+        poloidal_flux_enter=1.0,
+        field=field,
+    )
+
+    assert np.isclose(zeta, 0.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #111 

Now uses a the roots of a polynomial fit to the poloidal flux along a straight line from the launch position to make an initial guess as to the entry point, before using more the accurate root finder.

This does unfortunately change the initial `Psi` R-zeta component a little. @valerian-chen Does it make sense to enforce those components to be exactly zero when launching the beam?

@fongkenrui Please could you check this for your cases?

