### PR TITLE
Switch to h5netcdf

### DIFF
--- a/TestFunctions/compareBfield.py
+++ b/TestFunctions/compareBfield.py
@@ -11,7 +11,7 @@ from scipy import interpolate as interpolate
 from scipy import constants as constants
 import matplotlib.pyplot as plt
 from scotty.fun_FFD import find_dpolflux_dR, find_dpolflux_dZ # For find_B if using efit files directly
-from netCDF4 import Dataset
+from h5netcdf.legacyapi import Dataset
 
 
 

--- a/WorkInProgress/Scotty_beam_me_up2.py
+++ b/WorkInProgress/Scotty_beam_me_up2.py
@@ -63,7 +63,7 @@ from scipy import linalg as linalg
 import matplotlib.pyplot as plt
 import os
 import sys
-from netCDF4 import Dataset
+from h5netcdf.legacyapi import Dataset
 import bisect
 import time
 

--- a/WorkInProgress/Scotty_beam_me_up_in_a_slab.py
+++ b/WorkInProgress/Scotty_beam_me_up_in_a_slab.py
@@ -62,7 +62,7 @@ from scipy import linalg as linalg
 import matplotlib.pyplot as plt
 import os
 import sys
-from netCDF4 import Dataset
+from h5netcdf.legacyapi import Dataset
 import bisect
 import time
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "numpy~=1.20",
     "scipy~=1.7",
     "matplotlib~=3.3",
-    "netCDF4~=1.5",
     "freeqdsk==0.1.0",
     "xarray>=2023.01.0",
     "xarray-datatree",

--- a/scotty/analysis.py
+++ b/scotty/analysis.py
@@ -456,9 +456,7 @@ def further_analysis(
     g_zeta_Cardano = grad_H_Cardano("K_zeta", inputs.delta_K_zeta)
     g_Z_Cardano = grad_H_Cardano("K_Z", inputs.delta_K_Z)
     # This has maximum imaginary component of like 1e-16 -- should just be real?
-    g_magnitude_Cardano = np.sqrt(
-        g_R_Cardano**2 + g_zeta_Cardano**2 + g_Z_Cardano**2
-    )
+    g_magnitude_Cardano = np.sqrt(g_R_Cardano**2 + g_zeta_Cardano**2 + g_Z_Cardano**2)
 
     ##
     # From here on, we use the shorthand

--- a/scotty/check_ModeConversion.py
+++ b/scotty/check_ModeConversion.py
@@ -108,9 +108,7 @@ def plot(suffix=""):
     Booker_beta = -epsilon_perp_output * epsilon_para_output * (1 + sin_theta_m_sq) - (
         epsilon_perp_output**2 - epsilon_g_output**2
     ) * (1 - sin_theta_m_sq)
-    Booker_gamma = epsilon_para_output * (
-        epsilon_perp_output**2 - epsilon_g_output**2
-    )
+    Booker_gamma = epsilon_para_output * (epsilon_perp_output**2 - epsilon_g_output**2)
 
     N_X = find_N(Booker_alpha, Booker_beta, Booker_gamma, -1)
     N_O = find_N(Booker_alpha, Booker_beta, Booker_gamma, 1)

--- a/scotty/fun_general.py
+++ b/scotty/fun_general.py
@@ -260,14 +260,10 @@ def find_Psi_3D_lab(Psi_3D_lab_Cartesian, q_R, q_zeta, K_R, K_zeta):
     Psi_3D_lab = np.zeros([3, 3], dtype="complex128")
 
     Psi_3D_lab[0][0] = (
-        Psi_XX * cos_zeta**2
-        + 2 * Psi_XY * sin_zeta * cos_zeta
-        + Psi_YY * sin_zeta**2
+        Psi_XX * cos_zeta**2 + 2 * Psi_XY * sin_zeta * cos_zeta + Psi_YY * sin_zeta**2
     )  # Psi_RR
     Psi_3D_lab[1][1] = (
-        Psi_XX * sin_zeta**2
-        - 2 * Psi_XY * sin_zeta * cos_zeta
-        + Psi_YY * cos_zeta**2
+        Psi_XX * sin_zeta**2 - 2 * Psi_XY * sin_zeta * cos_zeta + Psi_YY * cos_zeta**2
     ) * q_R**2 - K_R * q_R  # Psi_zetazeta
     Psi_3D_lab[2][2] = Psi_ZZ  # Psi_ZZ
 

--- a/scotty/geometry.py
+++ b/scotty/geometry.py
@@ -7,7 +7,7 @@ from abc import ABC
 import pathlib
 from typing import Callable, Optional, Tuple
 
-from netCDF4 import Dataset
+from h5netcdf.legacyapi import Dataset
 import numpy as np
 from scipy.interpolate import RectBivariateSpline, UnivariateSpline
 

--- a/scotty/init_bruv.py
+++ b/scotty/init_bruv.py
@@ -149,9 +149,9 @@ def get_parameters_for_Scotty(
 
         density_fit = ne_settings(diagnostic, shot, equil_time, find_ne_method)
         parameters["density_fit_method"] = density_fit.fit
-        parameters[
-            "poloidal_flux_zero_density"
-        ] = density_fit.poloidal_flux_zero_density
+        parameters["poloidal_flux_zero_density"] = (
+            density_fit.poloidal_flux_zero_density
+        )
 
     # MAST and MAST-U specific B-field and poloidal flux settings
     if find_B_method == "UDA":

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -12,9 +12,7 @@ def test_first_derivative():
 
 
 def test_2D_derivative():
-    result = derivative(
-        lambda x, y: np.sin(x) * y**2, ("x", "y"), {"x": 0.0, "y": 2.0}
-    )
+    result = derivative(lambda x, y: np.sin(x) * y**2, ("x", "y"), {"x": 0.0, "y": 2.0})
     assert np.isclose(result, 4.0)
 
 


### PR DESCRIPTION
Fixes #130

This avoids issues arising from `netCDF4` and `h5py` using incompatible HDF5 shared libraries